### PR TITLE
[FEAT] #15 - 오디오 인코더를 이용해 webm 형식을 mp3로 변환하는 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 
     // JSON
     implementation 'org.json:json:20231013'
+
+    // JAVE2 (Audio Converting)
+    implementation 'ws.schild:jave-all-deps:3.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparcs/team1/domain/mooddiary/service/MoodDiaryService.java
+++ b/src/main/java/com/sparcs/team1/domain/mooddiary/service/MoodDiaryService.java
@@ -38,18 +38,12 @@ public class MoodDiaryService {
 
         String fileName = String.valueOf(createDiaryRequest.memberId()) + moodDiary.getId() + ".mp3";
 
-        System.out.println(clovaSpeechClient.objectStorage(
-                storageService.uploadObjectStorage(fileName, createDiaryRequest.file()),
-                nestRequestEntity
-        ));
-
         String diary = getTextFromResponse(
                 clovaSpeechClient.objectStorage(
                         storageService.uploadObjectStorage(fileName, createDiaryRequest.file()),
                         nestRequestEntity
                 )
         );
-
         moodDiary.updateDiary(diary);
 
         return CreateDiaryResponse.of(

--- a/src/main/java/com/sparcs/team1/global/common/external/clova/storage/AudioConverter.java
+++ b/src/main/java/com/sparcs/team1/global/common/external/clova/storage/AudioConverter.java
@@ -1,0 +1,49 @@
+package com.sparcs.team1.global.common.external.clova.storage;
+
+import java.io.File;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import ws.schild.jave.Encoder;
+import ws.schild.jave.EncoderException;
+import ws.schild.jave.MultimediaObject;
+import ws.schild.jave.encode.AudioAttributes;
+import ws.schild.jave.encode.EncodingAttributes;
+
+@Component
+public class AudioConverter {
+
+    public File convertAudioToMp3(MultipartFile multipartFile) {
+        File tempFile = null;
+        File tempSourceFile = null;
+
+        try {
+            // MultipartFile을 File로 변환
+            tempSourceFile = File.createTempFile("source_audio", ".tmp");
+            multipartFile.transferTo(tempSourceFile);
+
+            AudioAttributes audio = new AudioAttributes();
+            audio.setCodec("libmp3lame");
+            audio.setBitRate(128000);
+            audio.setChannels(2);
+            audio.setSamplingRate(44100);
+
+            EncodingAttributes attrs = new EncodingAttributes();
+            attrs.setOutputFormat("mp3");
+            attrs.setAudioAttributes(audio);
+
+            Encoder encoder = new Encoder();
+
+            tempFile = File.createTempFile("converted_audio", ".mp3");
+            encoder.encode(new MultimediaObject(tempSourceFile), tempFile, attrs);
+        } catch (EncoderException | IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (tempSourceFile != null && tempSourceFile.exists()) {
+                tempSourceFile.delete();
+            }
+        }
+
+        return tempFile;
+    }
+}


### PR DESCRIPTION
# 💡 Issue
- resolved: #15 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- JAVE (자바 오디오-비디오 인코더) 라이브러리를 이용해 클라에서 webm 형식으로 전달받은 음성 파일을 mp3로 변환하여 ObjectStorage에 저장하는 로직을 구현했습니다.